### PR TITLE
Update widgets.py

### DIFF
--- a/content_gallery/widgets.py
+++ b/content_gallery/widgets.py
@@ -69,7 +69,7 @@ class ContentTypeSelect(forms.Select):
         # replace original choices
         self.choices = filtered_choices
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """
         Filters the choices and adds the JavaScript code
         to the HTML of the widget. Returns the HTML code
@@ -106,7 +106,7 @@ class ObjectIdSelect(forms.Select):
         # replace original choices
         self.choices = choices
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """
         Returns the HTML code of the widget with available choices.
         """
@@ -138,7 +138,7 @@ class ImageWidget(widgets.AdminFileWidget):
           %(input_text)s: %(input)s
         </p>'''
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """
         Renders custom widget with the image preview for uploaded images
         or the default widget if the image has not yet been uploaded.
@@ -169,7 +169,7 @@ class ImageInlineWidget(forms.Widget):
     """
     template_name = 'content_gallery/admin/edit_inline/image_widget.html'
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """
         Renders the widget using the template file.
         """


### PR DESCRIPTION
This is almost certainly because of this backwards-incompatible change in Django 2.1:

Support for Widget.render() methods without the renderer argument is removed.
You may have subclassed django.forms.widgets.Widget in your code, or in the code of one of your dependencies. The code may look like this:

from django.forms import widgets

```
class ExampleWidget(widgets.Widget):
    def render(self, name, value, attrs=None):
        # ...
```
You need to fix the method signature of render, so that it looks like this:

    

> def render(self, name, value, attrs=None, renderer=None):